### PR TITLE
Fix: use absolute /temperature/ paths so modules load under /site/

### DIFF
--- a/temperature/index.html
+++ b/temperature/index.html
@@ -6,10 +6,10 @@
     <meta name="theme-color" content="#0b0f14" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>Temperature — Card Game</title>
-    <link rel="manifest" href="./manifest.webmanifest" />
-    <link rel="icon" href="./icons/icon-192.png" />
-    <link rel="apple-touch-icon" href="./icons/icon-192.png" />
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="manifest" href="/temperature/manifest.webmanifest" />
+    <link rel="icon" href="/temperature/icons/icon-192.png" />
+    <link rel="apple-touch-icon" href="/temperature/icons/icon-192.png" />
+    <link rel="stylesheet" href="/temperature/styles.css" />
   </head>
   <body>
     <header class="app-bar">
@@ -59,7 +59,7 @@
         <div class="table-top">
           <div class="piles">
             <div class="pile" id="deck" aria-label="Deck" tabindex="0">
-              <div class="card back"><img class="card-img" alt="Deck" src="./assets/img/cards/back.png" /></div>
+              <div class="card back"><img class="card-img" alt="Deck" src="/temperature/assets/img/cards/back.png" /></div>
               <div class="count" id="deck-count">0</div>
             </div>
             <div class="pile" id="discard" aria-label="Discard" tabindex="0">
@@ -107,10 +107,10 @@
     </div>
 
     <script type="module">
-      import { wireServiceWorkerUpdates } from './src/sw-updates.js';
-      import { initUI } from './src/ui.js';
-      import { restoreOrInit } from './src/app.js';
-      import { initMultiplayer } from './src/ui-mp.js';
+      import { wireServiceWorkerUpdates } from '/temperature/src/sw-updates.js';
+      import { initUI } from '/temperature/src/ui.js';
+      import { restoreOrInit } from '/temperature/src/app.js';
+      import { initMultiplayer } from '/temperature/src/ui-mp.js';
 
       // Tabs wiring
       const tabs = [
@@ -136,7 +136,7 @@
       restoreOrInit();
 
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('./sw.js').then(reg => wireServiceWorkerUpdates(reg));
+        navigator.serviceWorker.register('/temperature/sw.js').then(reg => wireServiceWorkerUpdates(reg));
       }
     </script>
   </body>


### PR DESCRIPTION
Fixes Start Game and tab clicks by ensuring the PWA JS modules and assets load correctly when the app is embedded under /site/. Changes: switch to absolute /temperature/ URLs in temperature/index.html for manifest, icons, CSS, modules, SW, and deck back image. Prevents 404s that led to "Malformed arrow function parameter list" errors and disabled UI.